### PR TITLE
Scale nodes with distance

### DIFF
--- a/src/frame.js
+++ b/src/frame.js
@@ -67,8 +67,7 @@ define(["../lib/trackball-controls/TrackballControls"], function (TrackballContr
 
     Frame.prototype._initNodes = function (nodes) {
         var material = new THREE.ParticleSystemMaterial({
-            size: 4,
-            sizeAttenuation: false,
+            size: 0.2,
             vertexColors: true,
         });
         this.particles = new THREE.Geometry();


### PR DESCRIPTION
which I think just involves specifying `ParticleSystemMaterial({sizeAttenuation: true})`

For one thing, it might be nice to have the labels from #21 only appear when the node's displayed size is large enough.
